### PR TITLE
Added service parameter

### DIFF
--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -6,7 +6,8 @@
 define susefw::services (
     $ensure,    # present|absent
     $zone,      # DMZ|EXT|INT
-    $type       # service|tcpport|udpport
+    $type,       # service|tcpport|udpport
+    $service="$name" # service name|port 
     ) {
 
     include susefw
@@ -25,19 +26,19 @@ define susefw::services (
     }
 
     # combine type and service
-    $fw_rule = "${fw_type}${name}"
+    $fw_rule = "${fw_type}${service}"
 
     case $ensure {
         present: {
             exec { "susefw_add_${fw_rule}_${fw_zone}":
                 command => "yast firewall services add $fw_rule zone=$fw_zone",
-                unless  => "$helper $fw_zone $type $name",
+                unless  => "$helper $fw_zone $type $service",
             }
         }
         absent: {
             exec { "susefw_rm_${fw_rule}_${fw_zone}":
                 command => "yast firewall services remove $fw_rule zone=$fw_zone",
-                onlyif  => "$helper $fw_zone $type $name",
+                onlyif  => "$helper $fw_zone $type $service",
 
             }
         }


### PR DESCRIPTION
Using the name resulted in not being able to create multiple rules for the
same port: eg 2049/tcp and 2049/udp ( Duplicate declaration errors
)
Yes using the ports explicitly is not the way of the susefw, but i incorporated this
module alongside  http://forge.puppetlabs.com/puppetlabs/firewall and wanted to homogenize.

The service $paramter defaults to $name so this change should be backwards compatible
